### PR TITLE
Add MongoDB backend for expenses

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -4,11 +4,19 @@ import { AnalyticsChart } from '@/components/analytics-chart';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useExpenseStore } from '@/store/expense-store';
 import { BarChart3, TrendingUp, Calendar, DollarSign } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 export default function AnalyticsPage() {
-  const { expenses, getAnalyticsData } = useExpenseStore();
-  
-  const analyticsData = getAnalyticsData();
+  const { expenses, fetchExpenses, getAnalyticsData } = useExpenseStore();
+  const [analyticsData, setAnalyticsData] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetchExpenses();
+  }, [fetchExpenses]);
+
+  useEffect(() => {
+    getAnalyticsData().then(setAnalyticsData);
+  }, [expenses, getAnalyticsData]);
   const totalExpenses = expenses.reduce((sum, expense) => sum + expense.amount, 0);
   const averageMonthly = analyticsData.length > 0 ? 
     analyticsData.reduce((sum, month) => {

--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/mongodb';
+import Expense from '@/models/expense';
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  await dbConnect();
+  const expense = await Expense.findById(params.id).lean();
+  if (!expense) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(expense);
+}
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  await dbConnect();
+  const data = await req.json();
+  const expense = await Expense.findByIdAndUpdate(params.id, data, { new: true });
+  if (!expense) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(expense);
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  await dbConnect();
+  await Expense.findByIdAndDelete(params.id);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/expenses/analytics/route.ts
+++ b/app/api/expenses/analytics/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/mongodb';
+import Expense from '@/models/expense';
+
+export async function GET() {
+  await dbConnect();
+  const expenses = await Expense.find().lean();
+  const monthly: Record<string, Record<string, number>> = {};
+
+  expenses.forEach((e: any) => {
+    const month = e.date.slice(0,7);
+    if (!monthly[month]) monthly[month] = {};
+    if (!monthly[month][e.category]) monthly[month][e.category] = 0;
+    monthly[month][e.category] += e.amount;
+  });
+
+  const result = Object.entries(monthly)
+    .map(([month, categories]) => ({ month, ...categories }))
+    .sort((a, b) => a.month.localeCompare(b.month));
+
+  return NextResponse.json(result);
+}

--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/mongodb';
+import Expense from '@/models/expense';
+
+export async function POST(req: Request) {
+  await dbConnect();
+  const data = await req.json();
+  const expense = await Expense.create(data);
+  return NextResponse.json(expense, { status: 201 });
+}
+
+export async function GET(req: Request) {
+  await dbConnect();
+  const { searchParams } = new URL(req.url);
+  const query: any = {};
+
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+  if (from || to) {
+    query.date = {} as any;
+    if (from) query.date.$gte = from;
+    if (to) query.date.$lte = to;
+  }
+
+  const categories = searchParams.get('category');
+  if (categories) {
+    query.category = { $in: categories.split(',') };
+  }
+
+  const paymentModes = searchParams.get('paymentMode');
+  if (paymentModes) {
+    query.paymentMode = { $in: paymentModes.split(',') };
+  }
+
+  const expenses = await Expense.find(query).sort({ date: -1 }).lean();
+  return NextResponse.json(expenses);
+}

--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { ExpenseForm } from '@/components/expense-form';
 import { ExpenseList } from '@/components/expense-list';
 import { ExpenseFilters } from '@/components/expense-filters';
@@ -11,7 +11,11 @@ import { PlusCircle, Filter, List } from 'lucide-react';
 
 export default function ExpensesPage() {
   const [activeTab, setActiveTab] = useState('add');
-  const { expenses, getFilteredExpenses } = useExpenseStore();
+  const { expenses, getFilteredExpenses, fetchExpenses } = useExpenseStore();
+
+  useEffect(() => {
+    fetchExpenses();
+  }, [fetchExpenses]);
   
   const filteredExpenses = getFilteredExpenses();
   const totalExpenses = filteredExpenses.reduce((sum, expense) => sum + expense.amount, 0);

--- a/components/expense-form.tsx
+++ b/components/expense-form.tsx
@@ -50,7 +50,7 @@ export function ExpenseForm() {
   const onSubmit = async (data: FormData) => {
     setIsSubmitting(true);
     try {
-      addExpense({
+      await addExpense({
         amount: Number(data.amount),
         category: data.category,
         notes: data.notes || '',

--- a/components/expense-list.tsx
+++ b/components/expense-list.tsx
@@ -66,8 +66,8 @@ export function ExpenseList() {
     return 0;
   });
 
-  const handleDelete = (id: string) => {
-    deleteExpense(id);
+  const handleDelete = async (id: string) => {
+    await deleteExpense(id);
     toast.success('Expense deleted successfully');
   };
 

--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -1,0 +1,27 @@
+import mongoose from 'mongoose';
+
+const MONGODB_URI = process.env.MONGODB_URI as string;
+
+if (!MONGODB_URI) {
+  throw new Error('Please define the MONGODB_URI environment variable');
+}
+
+interface GlobalWithMongoose {
+  mongoose: { conn: typeof mongoose | null; promise: Promise<typeof mongoose> | null };
+}
+
+declare const global: GlobalWithMongoose & typeof globalThis;
+
+export default async function dbConnect() {
+  if (!global.mongoose) {
+    global.mongoose = { conn: null, promise: null };
+  }
+
+  if (global.mongoose.conn) return global.mongoose.conn;
+
+  if (!global.mongoose.promise) {
+    global.mongoose.promise = mongoose.connect(MONGODB_URI, { bufferCommands: false });
+  }
+  global.mongoose.conn = await global.mongoose.promise;
+  return global.mongoose.conn;
+}

--- a/models/expense.ts
+++ b/models/expense.ts
@@ -1,0 +1,33 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface IExpense extends Document {
+  amount: number;
+  category: string;
+  notes: string;
+  date: string;
+  paymentMode: string;
+  createdAt: string;
+}
+
+const ExpenseSchema = new Schema<IExpense>(
+  {
+    amount: { type: Number, required: true },
+    category: { type: String, required: true },
+    notes: { type: String, default: '' },
+    date: { type: String, required: true },
+    paymentMode: { type: String, required: true },
+    createdAt: { type: String, default: () => new Date().toISOString() },
+  },
+  {
+    toJSON: {
+      virtuals: true,
+      versionKey: false,
+      transform: (_, ret) => {
+        ret.id = ret._id.toString();
+        delete ret._id;
+      },
+    },
+  }
+);
+
+export default mongoose.models.Expense || mongoose.model<IExpense>('Expense', ExpenseSchema);

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "eslint-config-next": "13.5.1",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.446.0",
+        "mongoose": "^7.5.2",
         "next": "13.5.1",
         "next-themes": "^0.3.0",
         "postcss": "8.4.30",
@@ -299,6 +300,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz",
+      "integrity": "sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@next/env": {
@@ -1946,6 +1957,22 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw=="
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
@@ -2454,6 +2481,15 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bson": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.20.1"
       }
     },
     "node_modules/busboy": {
@@ -4485,6 +4521,19 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -4913,6 +4962,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -4951,6 +5006,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/kareem": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/keyv": {
@@ -5050,6 +5114,13 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5095,6 +5166,100 @@
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bson": "^5.5.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "optionalDependencies": {
+        "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.7.tgz",
+      "integrity": "sha512-5Bo4CrUxrPITrhMKsqUTOkXXo2CoRC5tXxVQhnddCzqDMwRXfyStrxj1oY865g8gaekSBhxAeNkYyUSJvGm9Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^5.5.0",
+        "kareem": "2.5.1",
+        "mongodb": "5.9.2",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ms": {
@@ -6167,6 +6332,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sift": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==",
+      "license": "MIT"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6186,6 +6357,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/sonner": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.5.0.tgz",
@@ -6202,6 +6397,22 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",
@@ -6620,6 +6831,18 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -6904,6 +7127,28 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-resizable-panels": "^2.1.3",
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",
+    "mongoose": "^7.5.2",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary
- remove static export setting so API routes work
- add MongoDB connection helper
- define Expense mongoose model
- implement expenses CRUD and analytics API routes
- update store to use API endpoints
- update components/pages to fetch data from server
- add mongoose dependency

## Testing
- `npm install`
- `NEXT_TELEMETRY_DISABLED=1 npm run build` *(fails: Failed to fetch font `Inter`)*

